### PR TITLE
fix(cros_sdk): Use new SDK tarball location!

### DIFF
--- a/buildbot/constants.py
+++ b/buildbot/constants.py
@@ -192,7 +192,7 @@ VERSION_FILE = os.path.join('src/third_party/coreos-overlay',
                             'coreos/config/chromeos_version.sh')
 SDK_VERSION_FILE = os.path.join('src/third_party/coreos-overlay',
                                 'coreos/binhost/host/sdk_version.conf')
-SDK_GS_BUCKET = 'coreos-sdk'
+SDK_GS_BUCKET = 'storage.core-os.net/coreos/sdk/experimental'
 
 BOTH_OVERLAYS = 'both'
 PUBLIC_OVERLAYS = 'public'

--- a/lib/gs.py
+++ b/lib/gs.py
@@ -20,7 +20,7 @@ from chromite.lib import osutils
 # method; we set it initially here just for the sake of making clear it
 # exists.
 GSUTIL_BIN = None
-PUBLIC_BASE_HTTPS_URL = 'http://storage.core-os.com/'
+PUBLIC_BASE_HTTPS_URL = 'https://commondatastorage.googleapis.com/'
 PRIVATE_BASE_HTTPS_URL = 'https://sandbox.google.com/storage/'
 BASE_GS_URL = 'gs://'
 

--- a/scripts/cros_sdk.py
+++ b/scripts/cros_sdk.py
@@ -35,15 +35,12 @@ NEEDED_TOOLS = ('curl', 'xz', 'unshare')
 
 def GetArchStageTarballs(version):
   """Returns the URL for a given arch/version"""
-  extension = {'bz2':'tbz2', 'xz':'tar.xz'}
-  return [toolchain.GetSdkURL(suburl='cros-sdk-%s.%s'
-                              % (version, extension[compressor]))
-          for compressor in COMPRESSION_PREFERENCE]
+  suburl = '%s/coreos-sdk-amd64-%s.tar.bz2' % (version, version)
+  return [toolchain.GetSdkURL(suburl=suburl)]
 
 
 def GetStage3Urls(version):
-  return [toolchain.GetSdkURL(suburl='stage3-amd64-%s.tar.%s' % (version, ext))
-          for ext in COMPRESSION_PREFERENCE]
+  return GetArchStageTarballs(version)
 
 
 def FetchRemoteTarballs(storage_dir, urls):


### PR DESCRIPTION
Note that this is using https://commondatastorage.googleapis.com since
our own name http://storage.core-os.net doesn't resolve yet. Also the
cros_sdk --bootstrap option will just fetch the same tarball since the
bootstrap process is now done from scratch via catalyst instead of from
a Gentoo stage3 tarball. At some point there will be a lot of old code
to clean up.
