### PR TITLE
fix(cros_setup_toolchains): Fix typo added in "Add --nogetbinpkg"

### DIFF
--- a/scripts/cros_setup_toolchains.py
+++ b/scripts/cros_setup_toolchains.py
@@ -377,7 +377,7 @@ def UpdateTargets(targets, usepkg, getbinpkg=True):
   cmd = [EMERGE_CMD, '--oneshot', '--update']
   if usepkg:
     if getbinpkg:
-      cmd.apend('--getbinpkg')
+      cmd.append('--getbinpkg')
     cmd.append('--usepkgonly')
 
   cmd.extend(packages)


### PR DESCRIPTION
This fixes an error in commit c6abf88f5e729e8a2cf3a71eba70a9feb14ac4fb
