### PR TITLE
fix(cros_setup_toolchains): Don't default to the gold linker.

### DIFF
--- a/scripts/cros_setup_toolchains.py
+++ b/scripts/cros_setup_toolchains.py
@@ -51,9 +51,6 @@ TARGET_VERSION_MAP = {
 }
 # Overrides for {gcc,binutils}-config, pick a package with particular suffix.
 CONFIG_TARGET_SUFFIXES = {
-  'binutils' : {
-    'x86_64-cros-linux-gnu' : '-gold',
-  },
 }
 # Global per-run cache that will be filled ondemand in by GetPackageMap()
 # function as needed.


### PR DESCRIPTION
We want a nice normal default toolchain, so disable gold.
