### PR TITLE
fix(cros_setup_toolchains): Always install packages when using crossdev

### DIFF
--- a/scripts/cros_setup_toolchains.py
+++ b/scripts/cros_setup_toolchains.py
@@ -115,7 +115,7 @@ class Crossdev(object):
     cmdbase = ['crossdev', '--show-fail-log']
     cmdbase.extend(['--env', 'FEATURES=splitdebug'])
     # Pick stable by default, and override as necessary.
-    cmdbase.extend(['-P', '--oneshot'])
+    cmdbase.extend(['-P', '--oneshot', '-P', '--selective=n'])
     if usepkg:
       if getbinpkg:
         cmdbase.extend(['-P', '--getbinpkg'])


### PR DESCRIPTION
The latest SDK tarballs include the cross toolchain but the build
process depends on the cross toolchain binary packages to be present
which they won't be if they didn't need to be upgrade/installed.

To avoid the situation force each package to be downloaded re-installed
when initializing a new chroot via crossdev instead of no-opping when
they are already installed. Future SDK builds will be updated to not
include the toolchain as before since it is just needlessly increasing
the SDK tarball size.
