### PR TITLE
fix(cros_sdk): HTTP/2.0 doesn't have 'OK' in 200 response header

### DIFF
--- a/scripts/cros_sdk.py
+++ b/scripts/cros_sdk.py
@@ -75,7 +75,7 @@ def FetchRemoteTarballs(storage_dir, urls):
     for header in result.output.splitlines():
       # We must walk the output to find the string '200 OK' for use cases where
       # a proxy is involved and may have pushed down the actual header.
-      if header.find('200 OK') != -1:
+      if header.find('200') != -1:
         successful = True
       elif header.lower().startswith("content-length:"):
         content_length = int(header.split(":", 1)[-1].strip())


### PR DESCRIPTION
With new HTTP/2.0 in curl, the response header no more has '200 OK' and
so the status check fails. Look only for '200' in the response headers.

Not sure if this is the right thing to do though. Do you think we should check for HTTP Versions and then look for 200 or 200 OK accordingly. Seems like an overkill to me.