### PR TITLE
cros_sdk: Handle HTTP/2 responses

### DIFF
--- a/scripts/cros_sdk.py
+++ b/scripts/cros_sdk.py
@@ -77,7 +77,8 @@ def FetchRemoteTarballs(storage_dir, urls):
       # a proxy is involved and may have pushed down the actual header.
       if (header.startswith("HTTP/1.0 200") or
           header.startswith("HTTP/1.1 200") or
-          header.startswith("HTTP/2.0 200")):
+          header.startswith("HTTP/2.0 200") or
+          header.startswith("HTTP/2 200")):
         successful = True
       elif header.lower().startswith("content-length:"):
         content_length = int(header.split(":", 1)[-1].strip())


### PR DESCRIPTION
Fix a reported failure by adding to the whitelisted responses.  It might make more sense to match a pattern, but this project is being replaced by cork, so this quick fix should be good enough.